### PR TITLE
feat:add sunburst page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,16 @@
       "version": "0.0.0",
       "dependencies": {
         "@carbon/charts-react": "^1.7.6",
+        "@types/d3": "^7.4.0",
         "@vitejs/plugin-react": "^4.0.0",
         "axios": "^1.4.0",
         "carbon-components-react": "^8.29.1",
+        "d3": "^7.8.4",
         "papaparse": "^5.4.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "react-router-dom": "^6.11.2"
+        "react-router-dom": "^6.11.2",
+        "sunburst-chart": "^1.19.0"
       },
       "devDependencies": {
         "@types/papaparse": "^5.3.7",
@@ -1359,6 +1362,233 @@
         "node": ">=10"
       }
     },
+    "node_modules/@types/d3": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.0.tgz",
+      "integrity": "sha512-jIfNVK0ZlxcuRDKtRS/SypEyOQ6UHaFQBKv032X45VvxSJ6Yi5G9behy9h6tNTHTDGh5Vq+KbmBjUWLgY4meCA==",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/d3-axis": "*",
+        "@types/d3-brush": "*",
+        "@types/d3-chord": "*",
+        "@types/d3-color": "*",
+        "@types/d3-contour": "*",
+        "@types/d3-delaunay": "*",
+        "@types/d3-dispatch": "*",
+        "@types/d3-drag": "*",
+        "@types/d3-dsv": "*",
+        "@types/d3-ease": "*",
+        "@types/d3-fetch": "*",
+        "@types/d3-force": "*",
+        "@types/d3-format": "*",
+        "@types/d3-geo": "*",
+        "@types/d3-hierarchy": "*",
+        "@types/d3-interpolate": "*",
+        "@types/d3-path": "*",
+        "@types/d3-polygon": "*",
+        "@types/d3-quadtree": "*",
+        "@types/d3-random": "*",
+        "@types/d3-scale": "*",
+        "@types/d3-scale-chromatic": "*",
+        "@types/d3-selection": "*",
+        "@types/d3-shape": "*",
+        "@types/d3-time": "*",
+        "@types/d3-time-format": "*",
+        "@types/d3-timer": "*",
+        "@types/d3-transition": "*",
+        "@types/d3-zoom": "*"
+      }
+    },
+    "node_modules/@types/d3-array": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.0.5.tgz",
+      "integrity": "sha512-Qk7fpJ6qFp+26VeQ47WY0mkwXaiq8+76RJcncDEfMc2ocRzXLO67bLFRNI4OX1aGBoPzsM5Y2T+/m1pldOgD+A=="
+    },
+    "node_modules/@types/d3-axis": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-3.0.2.tgz",
+      "integrity": "sha512-uGC7DBh0TZrU/LY43Fd8Qr+2ja1FKmH07q2FoZFHo1eYl8aj87GhfVoY1saJVJiq24rp1+wpI6BvQJMKgQm8oA==",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-brush": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-3.0.2.tgz",
+      "integrity": "sha512-2TEm8KzUG3N7z0TrSKPmbxByBx54M+S9lHoP2J55QuLU0VSQ9mE96EJSAOVNEqd1bbynMjeTS9VHmz8/bSw8rA==",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-chord": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-3.0.2.tgz",
+      "integrity": "sha512-abT/iLHD3sGZwqMTX1TYCMEulr+wBd0SzyOQnjYNLp7sngdOHYtNkMRI5v3w5thoN+BWtlHVDx2Osvq6fxhZWw=="
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-HKuicPHJuvPgCD+np6Se9MQvS6OCbJmOjGvylzMJRlDwUXjKTTXs6Pwgk79O09Vj/ho3u1ofXnhFOaEWWPrlwA=="
+    },
+    "node_modules/@types/d3-contour": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-3.0.2.tgz",
+      "integrity": "sha512-k6/bGDoAGJZnZWaKzeB+9glgXCYGvh6YlluxzBREiVo8f/X2vpTEdgPy9DN7Z2i42PZOZ4JDhVdlTSTSkLDPlQ==",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-delaunay": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.1.tgz",
+      "integrity": "sha512-tLxQ2sfT0p6sxdG75c6f/ekqxjyYR0+LwPrsO1mbC9YDBzPJhs2HbJJRrn8Ez1DBoHRo2yx7YEATI+8V1nGMnQ=="
+    },
+    "node_modules/@types/d3-dispatch": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-3.0.2.tgz",
+      "integrity": "sha512-rxN6sHUXEZYCKV05MEh4z4WpPSqIw+aP7n9ZN6WYAAvZoEAghEK1WeVZMZcHRBwyaKflU43PCUAJNjFxCzPDjg=="
+    },
+    "node_modules/@types/d3-drag": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.2.tgz",
+      "integrity": "sha512-qmODKEDvyKWVHcWWCOVcuVcOwikLVsyc4q4EBJMREsoQnR2Qoc2cZQUyFUPgO9q4S3qdSqJKBsuefv+h0Qy+tw==",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-dsv": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-3.0.1.tgz",
+      "integrity": "sha512-76pBHCMTvPLt44wFOieouXcGXWOF0AJCceUvaFkxSZEu4VDUdv93JfpMa6VGNFs01FHfuP4a5Ou68eRG1KBfTw=="
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.0.tgz",
+      "integrity": "sha512-aMo4eaAOijJjA6uU+GIeW018dvy9+oH5Y2VPPzjjfxevvGQ/oRDs+tfYC9b50Q4BygRR8yE2QCLsrT0WtAVseA=="
+    },
+    "node_modules/@types/d3-fetch": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-3.0.2.tgz",
+      "integrity": "sha512-gllwYWozWfbep16N9fByNBDTkJW/SyhH6SGRlXloR7WdtAaBui4plTP+gbUgiEot7vGw/ZZop1yDZlgXXSuzjA==",
+      "dependencies": {
+        "@types/d3-dsv": "*"
+      }
+    },
+    "node_modules/@types/d3-force": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.4.tgz",
+      "integrity": "sha512-q7xbVLrWcXvSBBEoadowIUJ7sRpS1yvgMWnzHJggFy5cUZBq2HZL5k/pBSm0GdYWS1vs5/EDwMjSKF55PDY4Aw=="
+    },
+    "node_modules/@types/d3-format": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-3.0.1.tgz",
+      "integrity": "sha512-5KY70ifCCzorkLuIkDe0Z9YTf9RR2CjBX1iaJG+rgM/cPP+sO+q9YdQ9WdhQcgPj1EQiJ2/0+yUkkziTG6Lubg=="
+    },
+    "node_modules/@types/d3-geo": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.0.3.tgz",
+      "integrity": "sha512-bK9uZJS3vuDCNeeXQ4z3u0E7OeJZXjUgzFdSOtNtMCJCLvDtWDwfpRVWlyt3y8EvRzI0ccOu9xlMVirawolSCw==",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-hierarchy": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
+      "integrity": "sha512-9hjRTVoZjRFR6xo8igAJyNXQyPX6Aq++Nhb5ebrUF414dv4jr2MitM2fWiOY475wa3Za7TOS2Gh9fmqEhLTt0A=="
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-jx5leotSeac3jr0RePOH1KdR9rISG91QIE4Q2PYTu4OymLTZfA3SrnURSLzKH48HmXVUru50b8nje4E79oQSQw==",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.0.0.tgz",
+      "integrity": "sha512-0g/A+mZXgFkQxN3HniRDbXMN79K3CdTpLsevj+PXiTcb2hVyvkZUBg37StmgCQkaD84cUJ4uaDAWq7UJOQy2Tg=="
+    },
+    "node_modules/@types/d3-polygon": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-3.0.0.tgz",
+      "integrity": "sha512-D49z4DyzTKXM0sGKVqiTDTYr+DHg/uxsiWDAkNrwXYuiZVd9o9wXZIo+YsHkifOiyBkmSWlEngHCQme54/hnHw=="
+    },
+    "node_modules/@types/d3-quadtree": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-3.0.2.tgz",
+      "integrity": "sha512-QNcK8Jguvc8lU+4OfeNx+qnVy7c0VrDJ+CCVFS9srBo2GL9Y18CnIxBdTF3v38flrGy5s1YggcoAiu6s4fLQIw=="
+    },
+    "node_modules/@types/d3-random": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-3.0.1.tgz",
+      "integrity": "sha512-IIE6YTekGczpLYo/HehAy3JGF1ty7+usI97LqraNa8IiDur+L44d0VOjAvFQWJVdZOJHukUJw+ZdZBlgeUsHOQ=="
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.3.tgz",
+      "integrity": "sha512-PATBiMCpvHJSMtZAMEhc2WyL+hnzarKzI6wAHYjhsonjWJYGq5BXTzQjv4l8m2jO183/4wZ90rKvSeT7o72xNQ==",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-scale-chromatic": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.0.0.tgz",
+      "integrity": "sha512-dsoJGEIShosKVRBZB0Vo3C8nqSDqVGujJU6tPznsBJxNJNwMF8utmS83nvCBKQYPpjCzaaHcrf66iTRpZosLPw=="
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.5.tgz",
+      "integrity": "sha512-xCB0z3Hi8eFIqyja3vW8iV01+OHGYR2di/+e+AiOcXIOrY82lcvWW8Ke1DYE/EUVMsBl4Db9RppSBS3X1U6J0w=="
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.1.tgz",
+      "integrity": "sha512-6Uh86YFF7LGg4PQkuO2oG6EMBRLuW9cbavUW46zkIO5kuS2PfTqo2o9SkgtQzguBHbLgNnU90UNsITpsX1My+A==",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.0.tgz",
+      "integrity": "sha512-sZLCdHvBUcNby1cB6Fd3ZBrABbjz3v1Vm90nysCQ6Vt7vd6e/h9Lt7SiJUoEX0l4Dzc7P5llKyhqSi1ycSf1Hg=="
+    },
+    "node_modules/@types/d3-time-format": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-4.0.0.tgz",
+      "integrity": "sha512-yjfBUe6DJBsDin2BMIulhSHmr5qNR5Pxs17+oW4DoVPyVIXZ+m6bs7j1UVKP08Emv6jRmYrYqxYzO63mQxy1rw=="
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.0.tgz",
+      "integrity": "sha512-HNB/9GHqu7Fo8AQiugyJbv6ZxYz58wef0esl4Mv828w1ZKpAshw/uFWVDUcIB9KKFeFKoxS3cHY07FFgtTRZ1g=="
+    },
+    "node_modules/@types/d3-transition": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.3.tgz",
+      "integrity": "sha512-/S90Od8Id1wgQNvIA8iFv9jRhCiZcGhPd2qX0bKF/PS+y0W5CrXKgIiELd2CvG1mlQrWK/qlYh3VxicqG1ZvgA==",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-zoom": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.3.tgz",
+      "integrity": "sha512-OWk1yYIIWcZ07+igN6BeoG6rqhnJ/pYe+R1qWFM2DtW49zsoSjgb9G5xB0ZXA8hh2jAzey1XuRmMSoXdKw8MDA==",
+      "dependencies": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.10",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.10.tgz",
+      "integrity": "sha512-Nmh0K3iWQJzniTuPRcJn5hxXkfB1T1pgB89SBig5PlJQU5yocazeu4jATJlaA0GYFKWMqDdvYemoSnF2pXgLVA=="
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.11",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
@@ -1633,6 +1863,14 @@
       },
       "peerDependencies": {
         "vite": "^4"
+      }
+    },
+    "node_modules/accessor-fn": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/accessor-fn/-/accessor-fn-1.4.1.tgz",
+      "integrity": "sha512-P7yNKfmpuWLUwiRVk9RkRIPGjngemjZ7yANc0DL7otgDqEIWkEByMhShzfgQ5ZwCPEUmba4v1kOqCdGhpzY3ew==",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/acorn": {
@@ -2034,7 +2272,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
       "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
-      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -2087,7 +2324,6 @@
       "version": "7.8.4",
       "resolved": "https://registry.npmjs.org/d3/-/d3-7.8.4.tgz",
       "integrity": "sha512-q2WHStdhiBtD8DMmhDPyJmXUxr6VWRngKyiJ5EfXMxPw+tqT6BhNjhJZ4w3BHsNm3QoVfZLY8Orq/qPFczwKRA==",
-      "peer": true,
       "dependencies": {
         "d3-array": "3",
         "d3-axis": "3",
@@ -2128,7 +2364,6 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.3.tgz",
       "integrity": "sha512-JRHwbQQ84XuAESWhvIPaUV4/1UYTBOLiOPGWqgFDHZS1D5QN9c57FbH3QpEnQMYiOXNzKUQyGTZf+EVO7RT5TQ==",
-      "peer": true,
       "dependencies": {
         "internmap": "1 - 2"
       },
@@ -2140,7 +2375,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
       "integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2149,7 +2383,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
       "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
-      "peer": true,
       "dependencies": {
         "d3-dispatch": "1 - 3",
         "d3-drag": "2 - 3",
@@ -2165,7 +2398,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
       "integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
-      "peer": true,
       "dependencies": {
         "d3-path": "1 - 3"
       },
@@ -2190,7 +2422,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
       "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2199,7 +2430,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz",
       "integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
-      "peer": true,
       "dependencies": {
         "d3-array": "^3.2.0"
       },
@@ -2211,7 +2441,6 @@
       "version": "6.0.4",
       "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
       "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
-      "peer": true,
       "dependencies": {
         "delaunator": "5"
       },
@@ -2223,7 +2452,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
       "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2232,7 +2460,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
       "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
-      "peer": true,
       "dependencies": {
         "d3-dispatch": "1 - 3",
         "d3-selection": "3"
@@ -2245,7 +2472,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
       "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
-      "peer": true,
       "dependencies": {
         "commander": "7",
         "iconv-lite": "0.6",
@@ -2270,7 +2496,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
       "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2279,7 +2504,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
       "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
-      "peer": true,
       "dependencies": {
         "d3-dsv": "1 - 3"
       },
@@ -2291,7 +2515,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
       "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
-      "peer": true,
       "dependencies": {
         "d3-dispatch": "1 - 3",
         "d3-quadtree": "1 - 3",
@@ -2305,7 +2528,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
       "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2314,7 +2536,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.0.tgz",
       "integrity": "sha512-JEo5HxXDdDYXCaWdwLRt79y7giK8SbhZJbFWXqbRTolCHFI5jRqteLzCsq51NKbUoX0PjBVSohxrx+NoOUujYA==",
-      "peer": true,
       "dependencies": {
         "d3-array": "2.5.0 - 3"
       },
@@ -2326,7 +2547,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
       "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2335,7 +2555,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
       "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
-      "peer": true,
       "dependencies": {
         "d3-color": "1 - 3"
       },
@@ -2347,7 +2566,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
       "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2356,7 +2574,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz",
       "integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2365,7 +2582,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
       "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2374,7 +2590,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
       "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2418,7 +2633,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
       "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
-      "peer": true,
       "dependencies": {
         "d3-array": "2.10.0 - 3",
         "d3-format": "1 - 3",
@@ -2434,7 +2648,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.0.0.tgz",
       "integrity": "sha512-Lx9thtxAKrO2Pq6OO2Ua474opeziKr279P/TKZsMAhYyNDD3EnCffdbgeSYN5O7m2ByQsxtuP2CSDczNUIZ22g==",
-      "peer": true,
       "dependencies": {
         "d3-color": "1 - 3",
         "d3-interpolate": "1 - 3"
@@ -2447,7 +2660,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2456,7 +2668,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
       "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
-      "peer": true,
       "dependencies": {
         "d3-path": "^3.1.0"
       },
@@ -2468,7 +2679,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
       "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
-      "peer": true,
       "dependencies": {
         "d3-array": "2 - 3"
       },
@@ -2480,7 +2690,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
       "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
-      "peer": true,
       "dependencies": {
         "d3-time": "1 - 3"
       },
@@ -2492,7 +2701,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
       "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2501,7 +2709,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
       "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
-      "peer": true,
       "dependencies": {
         "d3-color": "1 - 3",
         "d3-dispatch": "1 - 3",
@@ -2520,7 +2727,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
       "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
-      "peer": true,
       "dependencies": {
         "d3-dispatch": "1 - 3",
         "d3-drag": "2 - 3",
@@ -2563,7 +2769,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.0.0.tgz",
       "integrity": "sha512-AyLvtyJdbv/U1GkiS6gUUzclRoAY4Gs75qkMygJJhU75LW4DNuSF2RMzpxs9jw9Oz1BobHjTdkG3zdP55VxAqw==",
-      "peer": true,
       "dependencies": {
         "robust-predicates": "^3.0.0"
       }
@@ -3007,6 +3212,18 @@
       "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
       "dev": true
     },
+    "node_modules/float-tooltip": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/float-tooltip/-/float-tooltip-1.2.1.tgz",
+      "integrity": "sha512-7Qi2BSSJTDj3qwyjLXhbnO6ii1wQsGrRuN283TftmAxj5kb3lXoeV7kSsu21COvgvZfJRfrGEttxgiNTDhVAbA==",
+      "dependencies": {
+        "d3-selection": "2 - 3",
+        "kapsule": "^1.14"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/follow-redirects": {
       "version": "1.15.2",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
@@ -3177,7 +3394,6 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "peer": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
@@ -3245,7 +3461,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
       "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -3366,6 +3581,17 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/kapsule": {
+      "version": "1.14.4",
+      "resolved": "https://registry.npmjs.org/kapsule/-/kapsule-1.14.4.tgz",
+      "integrity": "sha512-Ro1US5B5mtyZMM+NqW/0fqcBf9oEO7fG0gYY9FY+BVGo4KaonVsplFfuYx3pZ/GLCQfYE5cONduILLktsYjUpQ==",
+      "dependencies": {
+        "lodash-es": "4"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/levn": {
@@ -3899,8 +4125,7 @@
     "node_modules/robust-predicates": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.1.tgz",
-      "integrity": "sha512-ndEIpszUHiG4HtDsQLeIuMvRsDnn8c8rYStabochtUeCvfuvNptb5TUbVD68LRAILPX7p9nqQGh4xJgn3EHS/g==",
-      "peer": true
+      "integrity": "sha512-ndEIpszUHiG4HtDsQLeIuMvRsDnn8c8rYStabochtUeCvfuvNptb5TUbVD68LRAILPX7p9nqQGh4xJgn3EHS/g=="
     },
     "node_modules/rollup": {
       "version": "3.22.0",
@@ -3943,14 +4168,12 @@
     "node_modules/rw": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
-      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
-      "peer": true
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ=="
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "peer": true
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/sass": {
       "version": "1.62.1",
@@ -4060,6 +4283,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/sunburst-chart": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/sunburst-chart/-/sunburst-chart-1.19.0.tgz",
+      "integrity": "sha512-sD7izP96SzlHjbIFAqFMmhVMRL6XtlT+GtqKAZYsED1jS8VgoHT2s4hD/Sq0djWCgRLlmeLgOwR+cBI0xuUuXQ==",
+      "dependencies": {
+        "accessor-fn": "1",
+        "d3-hierarchy": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-path": "1 - 3",
+        "d3-scale": "1 - 4",
+        "d3-selection": "2 - 3",
+        "d3-shape": "1 - 3",
+        "d3-transition": "2 - 3",
+        "float-tooltip": "1",
+        "kapsule": "1"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/supports-color": {

--- a/package.json
+++ b/package.json
@@ -11,13 +11,16 @@
   },
   "dependencies": {
     "@carbon/charts-react": "^1.7.6",
+    "@types/d3": "^7.4.0",
     "@vitejs/plugin-react": "^4.0.0",
     "axios": "^1.4.0",
     "carbon-components-react": "^8.29.1",
+    "d3": "^7.8.4",
     "papaparse": "^5.4.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-router-dom": "^6.11.2"
+    "react-router-dom": "^6.11.2",
+    "sunburst-chart": "^1.19.0"
   },
   "devDependencies": {
     "@types/papaparse": "^5.3.7",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,8 +4,8 @@ import {
   createRoutesFromElements,
   Route,
 } from "react-router-dom";
-import { Feedback, Overview } from "./pages";
-import { feedbackLoader } from "./loaders";
+import { Feedback, Overview, SunburstPage } from "./pages";
+import { feedbackLoader, sunburstLoader } from "./loaders";
 import { Container } from "./layout";
 
 function App() {
@@ -17,6 +17,11 @@ function App() {
           path="/feedback"
           element={<Feedback />}
           loader={feedbackLoader}
+        />
+        <Route
+          path="/sunburst"
+          element={<SunburstPage />}
+          loader={sunburstLoader}
         />
       </Route>
     )

--- a/src/loaders/index.ts
+++ b/src/loaders/index.ts
@@ -13,7 +13,7 @@ export const feedbackLoader = (async (): Promise<ChartTabularData> => {
     (row: any) => !!row.state
   );
 
-  let data = filteredVaccinationData.map((row: any) => {
+  const data = filteredVaccinationData.map((row: any) => {
     const state: any = filteredPopulationdata.find(
       ({ state }: any) => state === row.state
     );
@@ -24,4 +24,42 @@ export const feedbackLoader = (async (): Promise<ChartTabularData> => {
   });
 
   return data;
+}) satisfies LoaderFunction;
+
+export const sunburstLoader = (async (): Promise<any> => {
+  const districtData = await fetcher("vaccination/vax_district.csv");
+  const chartData = districtData.reduce(
+    (result: any, row: any) => {
+      const { state, district, daily_partial } = row;
+
+      if (!state || !district) {
+        return result;
+      }
+
+      let stateNode = result.children.find((node: any) => node.name === state);
+
+      if (!stateNode) {
+        stateNode = { name: state, children: [] };
+        result.children.push(stateNode);
+      }
+
+      const districtNode = stateNode.children.find(
+        (node: any) => node.name === district
+      );
+
+      if (districtNode) {
+        districtNode.value += parseInt(daily_partial, 10);
+      } else {
+        stateNode.children.push({
+          name: district,
+          value: parseInt(daily_partial, 10),
+        });
+      }
+
+      return result;
+    },
+    { name: "home", children: [] }
+  );
+
+  return chartData;
 }) satisfies LoaderFunction;

--- a/src/pages/SunburstPage.tsx
+++ b/src/pages/SunburstPage.tsx
@@ -1,26 +1,18 @@
 import { sunburstLoader } from "../loaders";
 import Sunburst from "sunburst-chart";
-import { useEffect, useState } from "react";
+import { useEffect, useRef } from "react";
 import { scaleOrdinal, schemePaired } from "d3";
+import { useLoaderData } from "react-router-dom";
+import { LoaderData } from "../types";
 
 const SunburstPage = () => {
-  const [data, setData] = useState({});
-  // const data = useLoaderData() as LoaderData<typeof feedbackLoader>;
-  const color = scaleOrdinal(schemePaired);
+  const chartRef = useRef<HTMLDivElement>(null);
+  const data = useLoaderData() as LoaderData<typeof sunburstLoader>;
 
   useEffect(() => {
-    const loadChartData = async () => {
-      const chartData = await sunburstLoader();
-      setData(chartData);
-    };
-
-    loadChartData();
-  }, []);
-
-  useEffect(() => {
-    const chartElement = document.getElementById("chart");
-
+    const chartElement = chartRef.current;
     const updateChart = () => {
+      const color = scaleOrdinal(schemePaired);
       if (chartElement && Object.keys(data).length !== 0) {
         // Clear the existing chart content
         chartElement.innerHTML = "";
@@ -47,7 +39,7 @@ const SunburstPage = () => {
     return () => {
       window.removeEventListener("resize", handleResize);
     };
-  }, [data, color]);
+  }, [data]);
 
   return (
     <div>
@@ -56,7 +48,7 @@ const SunburstPage = () => {
         <span style={{ fontWeight: "bold" }}>Sunbursts Chart</span>
         (daily partial of vaccination by districts)
       </p>
-      <div id="chart" style={{ textAlign: "center" }} />
+      <div ref={chartRef} style={{ textAlign: "center" }} />
     </div>
   );
 };

--- a/src/pages/SunburstPage.tsx
+++ b/src/pages/SunburstPage.tsx
@@ -1,0 +1,64 @@
+import { sunburstLoader } from "../loaders";
+import Sunburst from "sunburst-chart";
+import { useEffect, useState } from "react";
+import { scaleOrdinal, schemePaired } from "d3";
+
+const SunburstPage = () => {
+  const [data, setData] = useState({});
+  // const data = useLoaderData() as LoaderData<typeof feedbackLoader>;
+  const color = scaleOrdinal(schemePaired);
+
+  useEffect(() => {
+    const loadChartData = async () => {
+      const chartData = await sunburstLoader();
+      setData(chartData);
+    };
+
+    loadChartData();
+  }, []);
+
+  useEffect(() => {
+    const chartElement = document.getElementById("chart");
+
+    const updateChart = () => {
+      if (chartElement && Object.keys(data).length !== 0) {
+        // Clear the existing chart content
+        chartElement.innerHTML = "";
+
+        const width = window.innerWidth <= 500 ? 200 : 400;
+        const height = window.innerWidth <= 500 ? 200 : 400;
+
+        Sunburst()
+          .data(data)
+          .width(width)
+          .height(height)
+          .color((obj) => color(obj.name || ""))(chartElement);
+      }
+    };
+
+    updateChart();
+
+    const handleResize = () => {
+      updateChart();
+    };
+
+    window.addEventListener("resize", handleResize);
+
+    return () => {
+      window.removeEventListener("resize", handleResize);
+    };
+  }, [data, color]);
+
+  return (
+    <div>
+      <h1>my covid view</h1>
+      <p>
+        <span style={{ fontWeight: "bold" }}>Sunbursts Chart</span>
+        (daily partial of vaccination by districts)
+      </p>
+      <div id="chart" style={{ textAlign: "center" }} />
+    </div>
+  );
+};
+
+export default SunburstPage;

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -1,2 +1,3 @@
 export { default as Overview } from "./Overview";
 export { default as Feedback } from "./Feedback";
+export { default as SunburstPage } from "./SunburstPage";


### PR DESCRIPTION
## PR by Impact Group

### Changes Made
- Added Sunburst chart component using vax_district dataset

### Screenshot
![image](https://github.com/omar-al-hendi/MyCovidView/assets/36974531/0497bd5e-50ec-40c9-bb30-ef4ea4f1789c)
![image](https://github.com/omar-al-hendi/MyCovidView/assets/36974531/f053d573-1b2e-4d1c-9d78-dd08dc833301)


### Additional Notes
- Carbon charts does not have a sunburst option, so an [external sunburst](https://github.com/vasturiano/sunburst-chart) package is used
