### PR TITLE
Simple Bar Chart - Total COVID-19 deaths in each state

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import {
   Route,
 } from "react-router-dom";
 import {
+  barLoader,
   feedbackLoader,
   sunburstLoader,
   treeMapLoader,
@@ -16,6 +17,7 @@ import {
   VaccinationRate,
   SunburstPage,
   TreemapPage,
+  BarChart,
 } from "./pages";
 import { Container } from "./layout";
 
@@ -43,6 +45,11 @@ function App() {
           path="/vaccination-rate"
           element={<VaccinationRate />}
           loader={vacRateLoader}
+        />
+        <Route
+          path="/bar"
+          element={<BarChart />}
+          loader={barLoader}
         />
       </Route>
     )

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,7 +5,7 @@ import {
   Route,
 } from "react-router-dom";
 import {
-  barLoader,
+  simpleBarLoader,
   feedbackLoader,
   sunburstLoader,
   treeMapLoader,
@@ -47,9 +47,9 @@ function App() {
           loader={vacRateLoader}
         />
         <Route
-          path="/bar"
+          path="/bar/:sortOrder?"
           element={<BarChart />}
-          loader={barLoader}
+          loader={simpleBarLoader}
         />
       </Route>
     )

--- a/src/loaders/index.ts
+++ b/src/loaders/index.ts
@@ -1,6 +1,7 @@
 import { fetcher } from "../utils";
 import { ChartTabularData } from "@carbon/charts/interfaces";
 import { LoaderFunction } from "react-router-dom";
+import { DeathsStateType } from "../types";
 
 export const feedbackLoader = (async (): Promise<ChartTabularData> => {
   const vaccinationData = await fetcher("vaccination/vax_state.csv");
@@ -175,22 +176,8 @@ export const vacRateLoader = (async (): Promise<ChartTabularData> => {
   return data_display;
 }) satisfies LoaderFunction;
 
-export const barLoader = (async (): Promise<ChartTabularData> => {
-  // const vaccinationData = await fetcher("vaccination/vax_state.csv");
-  // const populationData = await fetcher("static/population.csv");
-  const deathData = await fetcher<{
-    date: string,
-    state: string,
-    deaths_new: string,
-    deaths_bid: string,
-    deaths_new_dod: string,
-    deaths_bid_dod: string,
-    deaths_unvax: string,
-    deaths_pvax: string,
-    deaths_fvax: string,
-    deaths_boost: string,
-    deaths_tat: string
-  }>("epidemic/deaths_state.csv");
+export const simpleBarLoader = (async ({ params }): Promise<ChartTabularData> => {
+  const deathData = await fetcher<DeathsStateType>("epidemic/deaths_state.csv");
 
   const sumOfDeathForEachState: {[k: string]: number} = {};
 
@@ -208,6 +195,11 @@ export const barLoader = (async (): Promise<ChartTabularData> => {
     group: state,
     value: sumOfDeathForEachState[state],
   }))
+
+  // take sort order from the route path params
+  const { sortOrder } = params;
+  if (sortOrder === undefined) return data;
+  data.sort((a, b) => sortOrder === "asc" ? b.value - a.value : a.value - b.value);
 
   return data;
 }) satisfies LoaderFunction;

--- a/src/loaders/index.ts
+++ b/src/loaders/index.ts
@@ -198,7 +198,7 @@ export const simpleBarLoader = (async ({ params }): Promise<ChartTabularData> =>
 
   // take sort order from the route path params
   const { sortOrder } = params;
-  if (sortOrder === undefined) return data;
+  if (sortOrder === undefined || sortOrder !== "asc" && sortOrder !== "desc") return data;
   data.sort((a, b) => sortOrder === "asc" ? b.value - a.value : a.value - b.value);
 
   return data;

--- a/src/loaders/index.ts
+++ b/src/loaders/index.ts
@@ -174,3 +174,40 @@ export const vacRateLoader = (async (): Promise<ChartTabularData> => {
 
   return data_display;
 }) satisfies LoaderFunction;
+
+export const barLoader = (async (): Promise<ChartTabularData> => {
+  // const vaccinationData = await fetcher("vaccination/vax_state.csv");
+  // const populationData = await fetcher("static/population.csv");
+  const deathData = await fetcher<{
+    date: string,
+    state: string,
+    deaths_new: string,
+    deaths_bid: string,
+    deaths_new_dod: string,
+    deaths_bid_dod: string,
+    deaths_unvax: string,
+    deaths_pvax: string,
+    deaths_fvax: string,
+    deaths_boost: string,
+    deaths_tat: string
+  }>("epidemic/deaths_state.csv");
+
+  const sumOfDeathForEachState: {[k: string]: number} = {};
+
+  deathData.forEach((row) => {
+    const newDeaths = Number(row.deaths_new);
+    if (isNaN(newDeaths)) return;
+    if (sumOfDeathForEachState[row.state] === undefined) {
+      sumOfDeathForEachState[row.state] = Number(row.deaths_new);
+    } else {
+      sumOfDeathForEachState[row.state] += Number(row.deaths_new);
+    }
+  });
+
+  const data = Object.keys(sumOfDeathForEachState).map((state) => ({
+    group: state,
+    value: sumOfDeathForEachState[state],
+  }))
+
+  return data;
+}) satisfies LoaderFunction;

--- a/src/pages/Bar.tsx
+++ b/src/pages/Bar.tsx
@@ -1,0 +1,43 @@
+import { SimpleBarChart } from "@carbon/charts-react";
+import "@carbon/charts/styles.css";
+// Or
+// import "@carbon/charts/styles/styles.scss";
+
+// IBM Plex should either be imported in your project by using Carbon
+// or consumed manually through an import
+// import "./plex-and-carbon-components.css";
+import { useLoaderData } from "react-router-dom";
+import { ScaleTypes, AxisChartOptions } from "@carbon/charts/interfaces";
+import "@carbon/charts/styles.css";
+import "@carbon/styles/css/styles.css";
+import { LoaderData } from "../types";
+import { barLoader } from "../loaders";
+
+const options: AxisChartOptions = {
+	"title": "Total Death in Each State",
+	"axes": {
+		"left": {
+			"mapsTo": "group",
+      "title": "State",
+			"scaleType": ScaleTypes.LABELS,
+		},
+		"bottom": {
+      "title": "Total Death",
+			"mapsTo": "value"
+		}
+	},
+	"height": "400px",
+}
+
+const BarChart = () => {
+  const data = useLoaderData() as LoaderData<typeof barLoader>;
+
+	return (
+		<SimpleBarChart
+			data={data}
+			options={options} />
+	);
+}
+
+export default BarChart;
+  

--- a/src/pages/Bar.tsx
+++ b/src/pages/Bar.tsx
@@ -37,9 +37,9 @@ const BarChart = () => {
 			<select value={sortOrder} onChange={(event) => {
 				navigate(`/bar/${event.target.value}`)
 			}}>
+				<option value="">None</option>
 				<option value="asc">Ascending</option>
 				<option value="desc">Descending</option>
-				<option value="">None</option>
 			</select>
 		</div>
 	);

--- a/src/pages/Bar.tsx
+++ b/src/pages/Bar.tsx
@@ -1,28 +1,22 @@
 import { SimpleBarChart } from "@carbon/charts-react";
 import "@carbon/charts/styles.css";
-// Or
-// import "@carbon/charts/styles/styles.scss";
-
-// IBM Plex should either be imported in your project by using Carbon
-// or consumed manually through an import
-// import "./plex-and-carbon-components.css";
-import { useLoaderData } from "react-router-dom";
-import { ScaleTypes, AxisChartOptions } from "@carbon/charts/interfaces";
+import { useLoaderData, useNavigate, useParams } from "react-router-dom";
+import { ScaleTypes } from "@carbon/charts/interfaces";
 import "@carbon/charts/styles.css";
 import "@carbon/styles/css/styles.css";
 import { LoaderData } from "../types";
-import { barLoader } from "../loaders";
+import { simpleBarLoader } from "../loaders";
 
-const options: AxisChartOptions = {
+const options = {
 	"title": "Total Death in Each State",
 	"axes": {
 		"left": {
 			"mapsTo": "group",
-      "title": "State",
+			"title": "State",
 			"scaleType": ScaleTypes.LABELS,
 		},
 		"bottom": {
-      "title": "Total Death",
+			"title": "Total Death",
 			"mapsTo": "value"
 		}
 	},
@@ -30,12 +24,24 @@ const options: AxisChartOptions = {
 }
 
 const BarChart = () => {
-  const data = useLoaderData() as LoaderData<typeof barLoader>;
+  const data = useLoaderData() as LoaderData<typeof simpleBarLoader>;
+
+	const {sortOrder = ""} = useParams();
+	const navigate = useNavigate();
 
 	return (
-		<SimpleBarChart
-			data={data}
-			options={options} />
+		<div>
+			<SimpleBarChart
+				data={data}
+				options={options} />
+			<select value={sortOrder} onChange={(event) => {
+				navigate(`/bar/${event.target.value}`)
+			}}>
+				<option value="asc">Ascending</option>
+				<option value="desc">Descending</option>
+				<option value="">None</option>
+			</select>
+		</div>
 	);
 }
 

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -3,3 +3,4 @@ export { default as Feedback } from "./Feedback";
 export { default as SunburstPage } from "./SunburstPage";
 export { default as TreemapPage } from "./TreeMapPage";
 export { default as VaccinationRate } from "./VaccinationRate";
+export { default as BarChart } from "./Bar";

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -5,3 +5,17 @@ export type LoaderData<TLoaderFN extends LoaderFunction> = Awaited<
 > extends Response | infer D
   ? D
   : never;
+
+export type DeathsStateType = {
+  date: string,
+  state: string,
+  deaths_new: string,
+  deaths_bid: string,
+  deaths_new_dod: string,
+  deaths_bid_dod: string,
+  deaths_unvax: string,
+  deaths_pvax: string,
+  deaths_fvax: string,
+  deaths_boost: string,
+  deaths_tat: string
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -4,8 +4,8 @@ import Papa from "papaparse";
 const root =
   "https://raw.githubusercontent.com/MoH-Malaysia/covid19-public/main/";
 
-export const fetcher = async (url: string) => {
+export const fetcher = async <T extends {[key: string]: string}>(url: string): Promise<T[]> => {
   const { data: csvData } = await axios.get(root + url);
-  const { data } = Papa.parse(csvData, { header: true });
+  const { data } = Papa.parse<T>(csvData, { header: true });
   return data;
 };


### PR DESCRIPTION
- use generic type for fetcher
- added type definition of _deaths_state.csv_ columns
- added new route for simple bar chart
- added new loader for simple bar chart
- visualized data with bar chart
- enabled data sorting by value
