### PR TITLE
feat: single page for group 11 charts

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,17 +7,15 @@ import {
 import {
   Feedback,
   Overview,
-  VaccinationRate,
   SunburstPage,
   TreemapPage,
-  StackedBarChartPage,
+  Group11Page,
 } from "./pages";
 import {
   feedbackLoader,
   sunburstLoader,
   treeMapLoader,
-  vacRateLoader,
-  stackedBarLoader,
+  group11Loader,
 } from "./loaders";
 import { Container } from "./layout";
 
@@ -42,14 +40,9 @@ function App() {
           loader={treeMapLoader}
         />
         <Route
-          path="/vaccination-rate"
-          element={<VaccinationRate />}
-          loader={vacRateLoader}
-        />
-        <Route
-          path="/stackbarchart"
-          element={<StackedBarChartPage />}
-          loader={stackedBarLoader}
+          path="/group-11"
+          element={<Group11Page />}
+          loader={group11Loader}
         />
         <Route
           path="/sunburst"
@@ -60,11 +53,6 @@ function App() {
           path="/treemap"
           element={<TreemapPage />}
           loader={treeMapLoader}
-        />
-        <Route
-          path="/vaccination-rate"
-          element={<VaccinationRate />}
-          loader={vacRateLoader}
         />
       </Route>
     )

--- a/src/loaders/group11/index.ts
+++ b/src/loaders/group11/index.ts
@@ -1,0 +1,104 @@
+import { fetcher } from "../../utils";
+
+export const vacRateLoader = async () => {
+  const populationData = await fetcher("static/population.csv");
+  const popMalaysiaDataRow: any = populationData.find(
+    ({ state }: any) => state === "Malaysia"
+  );
+  const popMas = popMalaysiaDataRow["pop"];
+
+  const vaccineData = await fetcher("vaccination/vax_malaysia.csv");
+
+  //partial
+  const partialSum = vaccineData.reduce((sum: number, row: any) => {
+    const partial = parseInt(row["daily_partial"]);
+    return isNaN(partial) ? sum : sum + partial;
+  }, 0);
+
+  //fully
+  const fullSum = vaccineData.reduce((sum: number, row: any) => {
+    const full = parseInt(row["daily_full"]);
+    return isNaN(full) ? sum : sum + full;
+  }, 0);
+
+  //booster 1
+  const b1Sum = vaccineData.reduce((sum: number, row: any) => {
+    const b1 = parseInt(row["daily_booster"]);
+    return isNaN(b1) ? sum : sum + b1;
+  }, 0);
+
+  //booster 2
+  const b2Sum = vaccineData.reduce((sum: number, row: any) => {
+    const b2 = parseInt(row["daily_booster2"]);
+    return isNaN(b2) ? sum : sum + b2;
+  }, 0);
+  const data_display = [
+    {
+      title: "Partial Vaccinated",
+      group: "PV",
+      ranges: [0, 60, 80],
+      marker: 75,
+      max: 100,
+      value: Math.round((partialSum / popMas) * 100 * 100) / 100,
+    },
+    {
+      title: "Fully Vaccinated",
+      group: "FV",
+      ranges: [0, 60, 80],
+      marker: 75,
+      max: 100,
+      value: Math.round((fullSum / popMas) * 100 * 100) / 100,
+    },
+    {
+      title: "Booster 1",
+      group: "B1",
+      ranges: [0, 60, 80],
+      marker: 75,
+      max: 100,
+      value: Math.round((b1Sum / popMas) * 100 * 100) / 100,
+    },
+    {
+      title: "Booster 2",
+      group: "B2",
+      ranges: [0, 60, 80],
+      marker: 75,
+      max: 100,
+      value: Math.round((b2Sum / popMas) * 100 * 100) / 100,
+    },
+  ];
+
+  return data_display;
+};
+
+export const deathRateLoader = async () => {
+  const death_state = await fetcher("epidemic/deaths_state.csv");
+  const case_state = await fetcher("epidemic/cases_state.csv");
+
+  const filtered_death_state = death_state
+    .slice(-17)
+    .filter((row: any) => !!row.state);
+  const filtered_case_state = case_state
+    .slice(-17)
+    .filter((row: any) => !!row.state);
+
+  let data = filtered_death_state.map((row: any) => {
+    const cases: any = filtered_case_state.find(
+      ({ state }: any) => state === row.state
+    );
+    let data = [
+      {
+        key: row["state"],
+        group: "deaths_new",
+        value: +row["deaths_new"],
+      },
+      {
+        key: row["state"],
+        group: "cases_new",
+        value: +cases["cases_new"],
+      },
+    ];
+    return data;
+  });
+
+  return data;
+};

--- a/src/loaders/index.ts
+++ b/src/loaders/index.ts
@@ -5,13 +5,22 @@ import {
   progressBarLoader,
   testPositiveLoader,
 } from "./feedback";
-import { ChartTabularData } from "@carbon/charts/interfaces";
+import {
+  vacRateLoader,
+  deathRateLoader,
+} from "./group11";
 
 export const feedbackLoader = (async (): Promise<any> => {
   const progresssBarData = await progressBarLoader();
   const icuCapacityMeterData = await icuCapacityMeterLoader();
   const testPositiveGaugeData = await testPositiveLoader();
   return { progresssBarData, icuCapacityMeterData, testPositiveGaugeData };
+}) satisfies LoaderFunction;
+
+export const group11Loader = (async (): Promise<any> => {
+  const vacRateData = await vacRateLoader();
+  const deathRateData = await deathRateLoader();
+  return { vacRateData, deathRateData };
 }) satisfies LoaderFunction;
 
 export const sunburstLoader = (async (): Promise<any> => {
@@ -91,107 +100,4 @@ export const treeMapLoader = (async (): Promise<any[]> => {
   );
 
   return treeMapData;
-}) satisfies LoaderFunction;
-
-export const vacRateLoader = (async (): Promise<ChartTabularData> => {
-  const populationData = await fetcher("static/population.csv");
-  const popMalaysiaDataRow: any = populationData.find(
-    ({ state }: any) => state === "Malaysia"
-  );
-  const popMas = popMalaysiaDataRow["pop"];
-
-  const vaccineData = await fetcher("vaccination/vax_malaysia.csv");
-
-  //partial
-  const partialSum = vaccineData.reduce((sum: number, row: any) => {
-    const partial = parseInt(row["daily_partial"]);
-    return isNaN(partial) ? sum : sum + partial;
-  }, 0);
-
-  //fully
-  const fullSum = vaccineData.reduce((sum: number, row: any) => {
-    const full = parseInt(row["daily_full"]);
-    return isNaN(full) ? sum : sum + full;
-  }, 0);
-
-  //booster 1
-  const b1Sum = vaccineData.reduce((sum: number, row: any) => {
-    const b1 = parseInt(row["daily_booster"]);
-    return isNaN(b1) ? sum : sum + b1;
-  }, 0);
-
-  //booster 2
-  const b2Sum = vaccineData.reduce((sum: number, row: any) => {
-    const b2 = parseInt(row["daily_booster2"]);
-    return isNaN(b2) ? sum : sum + b2;
-  }, 0);
-  const data_display = [
-    {
-      title: "Partial Vaccinated",
-      group: "PV",
-      ranges: [0, 60, 80],
-      marker: 75,
-      max: 100,
-      value: Math.round((partialSum / popMas) * 100 * 100) / 100,
-    },
-    {
-      title: "Fully Vaccinated",
-      group: "FV",
-      ranges: [0, 60, 80],
-      marker: 75,
-      max: 100,
-      value: Math.round((fullSum / popMas) * 100 * 100) / 100,
-    },
-    {
-      title: "Booster 1",
-      group: "B1",
-      ranges: [0, 60, 80],
-      marker: 75,
-      max: 100,
-      value: Math.round((b1Sum / popMas) * 100 * 100) / 100,
-    },
-    {
-      title: "Booster 2",
-      group: "B2",
-      ranges: [0, 60, 80],
-      marker: 75,
-      max: 100,
-      value: Math.round((b2Sum / popMas) * 100 * 100) / 100,
-    },
-  ];
-
-  return data_display;
-}) satisfies LoaderFunction;
-
-export const stackedBarLoader = (async (): Promise<ChartTabularData> => {
-  const death_state = await fetcher("epidemic/deaths_state.csv");
-  const case_state = await fetcher("epidemic/cases_state.csv");
-
-  const filtered_death_state = death_state
-    .slice(-17)
-    .filter((row: any) => !!row.state);
-  const filtered_case_state = case_state
-    .slice(-17)
-    .filter((row: any) => !!row.state);
-
-  let data = filtered_death_state.map((row: any) => {
-    const cases: any = filtered_case_state.find(
-      ({ state }: any) => state === row.state
-    );
-    let data = [
-      {
-        key: row["state"],
-        group: "deaths_new",
-        value: +row["deaths_new"],
-      },
-      {
-        key: row["state"],
-        group: "cases_new",
-        value: +cases["cases_new"],
-      },
-    ];
-    return data;
-  });
-
-  return data;
 }) satisfies LoaderFunction;

--- a/src/pages/Group11/DeathRate.tsx
+++ b/src/pages/Group11/DeathRate.tsx
@@ -2,9 +2,6 @@ import { StackedBarChart } from '@carbon/charts-react';
 import '@carbon/charts/styles.css';
 import "@carbon/styles/css/styles.css";
 import { ScaleTypes } from '@carbon/charts/interfaces';
-import { useLoaderData } from 'react-router-dom';
-import { stackedBarLoader } from '../loaders';
-import { LoaderData } from '../types';
 
 const options = {
 	title: 'Daily Covid Cases and Deaths in Each State',
@@ -23,19 +20,18 @@ const options = {
 	height: '400px',
 };
 
-function StackedBarChartPage () {
-	const loaderData = useLoaderData() as LoaderData<typeof stackedBarLoader>;
-	let data: any[] = [];
-	loaderData.forEach((item: any) => {
-		data.push(...item);
+function DeathRate ({ data }: { data: any }) {
+	let processed_data: any[] = [];
+	data.forEach((item: any) => {
+		processed_data.push(...item);
 	})
 
 	return (
-		<div style={{ width: '100%', height: '400px' }}>
+		<div>
 			<h1>Stacked Bar Chart</h1>
-			<StackedBarChart data={data} options={options} />
+			<StackedBarChart data={processed_data} options={options} />
 		</div>
 	);
 }
 
-export default StackedBarChartPage;
+export default DeathRate;

--- a/src/pages/Group11/VaccinationRate.tsx
+++ b/src/pages/Group11/VaccinationRate.tsx
@@ -2,9 +2,6 @@ import BulletChart from "@carbon/charts-react/bullet-chart";
 import { ScaleTypes } from "@carbon/charts/interfaces";
 import "@carbon/charts/styles.css";
 import "@carbon/styles/css/styles.css";
-import { useLoaderData } from "react-router-dom";
-import { vacRateLoader } from "../loaders";
-import { LoaderData } from "../types";
 
 const options = {
     "title": "Percentage of Vaccinated People",
@@ -12,7 +9,7 @@ const options = {
         "bottom": {
             "mapsTo": "value",
             "extendLinearDomainBy": "max"
-        }, 
+        },
         "left": {
             "scaleType": ScaleTypes.LABELS,
             "mapsTo": "title"
@@ -25,14 +22,13 @@ const options = {
     "height": "400px"
 };
 
-const Vaccine = () => {
-    const data = useLoaderData() as LoaderData<typeof vacRateLoader>;
+const VaccinationRate = ({ data }: { data: any }) => {
     return (
         <div>
-            <h1>my covid view</h1>
+            <h1>Bullet Chart</h1>
             <BulletChart data={data} options={options} />
         </div>
     );
 };
 
-export default Vaccine;
+export default VaccinationRate;

--- a/src/pages/Group11/index.tsx
+++ b/src/pages/Group11/index.tsx
@@ -1,0 +1,26 @@
+import { group11Loader } from '../../loaders';
+import { useLoaderData } from 'react-router-dom';
+import { LoaderData } from '../../types';
+import VaccinationRate from './VaccinationRate';
+import DeathRate from './DeathRate';
+
+function Group11Page() {
+  const { vacRateData, deathRateData } = useLoaderData() as LoaderData<typeof group11Loader>;
+  return (
+    <div
+      style={{
+        display: "grid",
+        gap: "2rem",
+        background: "#e0e0e0",
+        padding: "2rem",
+        borderRadius: "1rem",
+        margin: "2rem",
+      }}
+    >
+      <VaccinationRate data={vacRateData} />
+      <DeathRate data={deathRateData} />
+    </div>
+  );
+}
+
+export default Group11Page

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -2,5 +2,4 @@ export { default as Overview } from "./Overview";
 export { default as Feedback } from "./Feedback";
 export { default as SunburstPage } from "./SunburstPage";
 export { default as TreemapPage } from "./TreeMapPage";
-export { default as StackedBarChartPage } from "./StackedBarChartPage";
-export { default as VaccinationRate } from "./VaccinationRate";
+export { default as Group11Page } from "./Group11";


### PR DESCRIPTION
- created a single page for bullet chart and stacked bar chart with route path= `/group-11`
- the charts and the page are moved into the `pages/Group 11` folder
- the loader functions also moved to the `index.ts` file in the `loaders/group 11` folder
- StackedBarChartPage is renamed to DeathRate

p.s:
tried to run `git rebase main` but the terminal says "current branch is up to date"