### PR TITLE
(Group 11) feat: date in stackedBarChart

### DIFF
--- a/src/loaders/group11/index.ts
+++ b/src/loaders/group11/index.ts
@@ -90,11 +90,13 @@ export const deathRateLoader = async () => {
         key: row["state"],
         group: "deaths_new",
         value: +row["deaths_new"],
+        date: row["date"],
       },
       {
         key: row["state"],
         group: "cases_new",
         value: +cases["cases_new"],
+        date: cases["date"],
       },
     ];
     return data;

--- a/src/pages/Group11/DeathRate.tsx
+++ b/src/pages/Group11/DeathRate.tsx
@@ -27,6 +27,7 @@ function DeathRate ({ data }: { data: any }) {
 	return (
 		<div>
 			<h1>Stacked Bar Chart</h1>
+			<p>{processed_data[0].date}</p>
 			<StackedBarChart data={processed_data} options={options} />
 		</div>
 	);


### PR DESCRIPTION
Closes #

Added date in the StackedBarChart as requested by Dr.

#### Changelog

**New**

Add date element in `DeathRate.tsx`

**Changed**

Change the data returned from `deathRateLoader` in `loaders/group11/` to return date

#### Testing / Reviewing

Check the StackedBarChart whether is there a date under the title, and does the chart displayed properly

#### Screenshots

![image](https://github.com/omar-al-hendi/MyCovidView/assets/77727316/d6025089-635c-42c1-9369-5c99ac9822a6)

