### PR TITLE
Show charts in Import Page according to dataset imported

### DIFF
--- a/src/indexedDB/index.ts
+++ b/src/indexedDB/index.ts
@@ -1,14 +1,15 @@
 import Dexie, { Table } from "dexie";
 
 const dbName = "SPQDB";
-const storeName = "store";
 
 class Store extends Dexie {
+  source!: Table;
   store!: Table;
   constructor() {
     super(dbName);
     this.version(1).stores({
-      [storeName]: "++id",
+      source: "++id",
+      store: "++id",
     });
   }
 }
@@ -19,6 +20,6 @@ export const initDB = async (fields: string) => {
   db.close();
   db.on("blocked", () => false); // Silence console warning of blocked event.
   await db.delete();
-  db.version(1).stores({ [storeName]: fields });
+  db.version(1).stores({ source: "++id", store: fields });
   await db.open();
 };

--- a/src/pages/GroupGalaxy/ColumnChart.tsx
+++ b/src/pages/GroupGalaxy/ColumnChart.tsx
@@ -3,7 +3,7 @@ import { ScaleTypes } from "@carbon/charts/interfaces";
 
 const options = {
   title:
-    "Percentage of Fully Vaccinated Adults and Children Across Differnet Malaysia States",
+    "Percentage of Fully Vaccinated Adults and Children Across Different Malaysia States",
   axes: {
     left: {
       title: "Percentage of fully vaccinated people (%)",

--- a/src/pages/GroupGalaxy/index.tsx
+++ b/src/pages/GroupGalaxy/index.tsx
@@ -5,19 +5,19 @@ import ColumnChart from "./ColumnChart";
 import BarChart from "./BarChart";
 
 const GroupGalaxyPage = () => {
-  const { columnChartData, barChartData } =
-    useLoaderData() as LoaderData<typeof groupGalaxyLoader>;
+  const { columnChartData, barChartData } = useLoaderData() as LoaderData<
+    typeof groupGalaxyLoader
+  >;
   return (
     <div>
       <div
         style={{
           display: "grid",
           gap: "2rem",
-          background: "#b4d0e7",
+          background: "#e0e0e0",
           padding: "2rem",
-          borderRadius: "2rem",
+          borderRadius: "1rem",
           margin: "2rem",
-          boxShadow: "0px 5px 10px rgba(0, 0, 0, 0.2)",
         }}
       >
         <ColumnChart data={columnChartData} />

--- a/src/pages/Import/ImportModal.tsx
+++ b/src/pages/Import/ImportModal.tsx
@@ -75,7 +75,7 @@ const ImportModal = (props: {
     results.meta.fields?.forEach((field) => fields.push(field));
     setIsLoading(true);
     await initDB(fields.join(","));
-    if (url.current.length > 0) await db.source.add({ url: url.current });
+    await db.source.add({ url: url.current });
     db.store
       .bulkAdd(results.data)
       .then(async () => {

--- a/src/pages/Import/ImportModal.tsx
+++ b/src/pages/Import/ImportModal.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { initDB, db } from "../../indexedDB";
 import {
   Button,
@@ -24,6 +24,7 @@ const ImportModal = (props: {
 }) => {
   const { closeModal, setIsLoading, setShowNotification } = props;
   const [dataSourceType, setDataSourceType] = useState<"file" | "url">("file");
+  const url = useRef("");
 
   const toggleDataSourceType = (event: ContentSwitcherOnChangeData) => {
     if (event.name !== "file" && event.name !== "url") return;
@@ -48,6 +49,7 @@ const ImportModal = (props: {
       setIsLoading(true);
       try {
         data = (await axios.get(input.value)).data;
+        url.current = input.value;
       } catch {
         setIsLoading(false);
         setShowNotification("error");
@@ -73,6 +75,7 @@ const ImportModal = (props: {
     results.meta.fields?.forEach((field) => fields.push(field));
     setIsLoading(true);
     await initDB(fields.join(","));
+    if (url.current.length > 0) await db.source.add({ url: url.current });
     db.store
       .bulkAdd(results.data)
       .then(async () => {

--- a/src/pages/Import/index.tsx
+++ b/src/pages/Import/index.tsx
@@ -1,8 +1,10 @@
-import { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { db, initDB } from "../../indexedDB";
 import {
   DenormalizedRow,
+  Dropdown,
   Loading,
+  OnChangeData,
   ToastNotification,
 } from "carbon-components-react";
 import IDataTable from "./DataTable";
@@ -10,6 +12,18 @@ import IModal from "./IModal";
 import ImportModal from "./ImportModal";
 import { useLiveQuery } from "dexie-react-hooks";
 import { SortInfo } from "./useSortInfo";
+import { boxPlotLoader, histogramLoader } from "../../loaders/distribution";
+import { areaChartLoader, lineChartLoader } from "../../loaders/fantasy";
+import { casesLoader } from "../../loaders/group13";
+import { stackedLineLoader } from "../../loaders/group2";
+import { stackedAreaLoader } from "../../loaders/group5";
+import BoxPlot from "../Distribution/BoxPlot";
+import Histogram from "../Distribution/Histogram";
+import LineChartPage from "../fantasy/LineChartPage";
+import KpiDashboard from "../Group13/KpiDashboard";
+import StackedLine from "../Group2/RecoverTrend";
+import AreaChartPage from "../fantasy/AreaChartPage";
+import VaccineDoseType from "../Group5/VaccineDoseType";
 
 const ImportPage = () => {
   const [open, setOpen] = useState<
@@ -29,15 +43,27 @@ const ImportPage = () => {
   });
   const totalItemsLength = useLiveQuery(
     async () => {
-      if (!db.isOpen()) return 0;
+      if (!db.isOpen()) await db.open();
       return db.store.filter(searchText).count();
     },
     [queryParams.searchString],
     0
   );
+  const source = useLiveQuery(
+    async () => {
+      if (!db.isOpen()) await db.open();
+      const record = await db.source.get(1);
+      return record.url.replace(
+        "https://raw.githubusercontent.com/MoH-Malaysia/covid19-public/main/",
+        ""
+      );
+    },
+    [],
+    ""
+  );
   const data = useLiveQuery(
     async () => {
-      if (!db.isOpen()) return [];
+      if (!db.isOpen()) await db.open();
       const { page, pageSize, sortInfo } = queryParams;
       const record = (await db.store.get(1)) ?? {};
       const sortHeaderExists = Object.keys(record).includes(sortInfo.columnId);
@@ -58,9 +84,74 @@ const ImportPage = () => {
         .limit(pageSize)
         .toArray();
     },
-    [queryParams],
+    [
+      queryParams.page,
+      queryParams.pageSize,
+      queryParams.searchString,
+      queryParams.sortInfo.columnId,
+      queryParams.sortInfo.direction,
+    ],
     []
   );
+  const chartsAvailable: {
+    [key: string]: Array<{
+      title: string;
+      loader: () => Promise<any>;
+      component: any;
+    }>;
+  } = {
+    "epidemic/cases_malaysia.csv": [
+      { title: "Box Plot", loader: boxPlotLoader, component: BoxPlot },
+      { title: "Histogram", loader: histogramLoader, component: Histogram },
+      {
+        title: "Line Chart",
+        loader: lineChartLoader,
+        component: LineChartPage,
+      },
+      { title: "KPI Dashboard", loader: casesLoader, component: KpiDashboard },
+      {
+        title: "Stacked Line Chart",
+        loader: stackedLineLoader,
+        component: StackedLine,
+      },
+    ],
+    "vaccination/vax_malaysia.csv": [
+      {
+        title: "Area Chart",
+        loader: areaChartLoader,
+        component: AreaChartPage,
+      },
+      {
+        title: "Stacked Area Chart",
+        loader: stackedAreaLoader,
+        component: VaccineDoseType,
+      },
+    ],
+  };
+  const [chartSelected, setChartSelected] = useState<any>("");
+  const [chartComponent, setChartComponent] = useState<any>(null);
+
+  useEffect(() => {
+    if (totalItemsLength === 0) setChartSelected("");
+  }, [totalItemsLength]);
+
+  useEffect(() => {
+    const renderChart = () => {
+      const chartConfig = chartsAvailable[source]?.find(
+        (chart) => chart.title === chartSelected
+      );
+      if (!chartConfig) return;
+      const Chart = chartConfig.component;
+      chartConfig.loader().then((data) => {
+        setChartComponent(<Chart data={data} />);
+      });
+    };
+    renderChart();
+  }, [chartSelected, data]);
+
+  const onChange = (e: OnChangeData) => {
+    setChartSelected(e.selectedItem);
+  };
 
   const searchText = (record: object) => {
     return (
@@ -231,8 +322,13 @@ const ImportPage = () => {
   return (
     <div
       style={{
-        background: "rgb(224, 224, 224)",
+        display: "flex",
+        flexDirection: "column",
+        gap: "2rem",
+        background: "#e0e0e0",
+        padding: "2rem",
         borderRadius: "1rem",
+        margin: "2rem",
       }}
     >
       {showNotification === "success" || showNotification === "error" ? (
@@ -305,6 +401,20 @@ const ImportPage = () => {
           danger
         />
       ) : null}
+      {totalItemsLength !== 0 && chartsAvailable[source] && (
+        <>
+          <div style={{ width: 450, alignSelf: "end" }}>
+            <Dropdown
+              id="dropdown"
+              direction="top"
+              label="Choose the chart to display"
+              items={chartsAvailable[source].map((chart) => chart.title)}
+              onChange={onChange}
+            />
+          </div>
+          <div>{chartComponent}</div>
+        </>
+      )}
     </div>
   );
 };

--- a/src/pages/Import/index.tsx
+++ b/src/pages/Import/index.tsx
@@ -142,7 +142,11 @@ const ImportPage = () => {
       const chartConfig = chartsAvailable[source]?.find(
         (chart) => chart.title === chartSelected
       );
-      if (!chartConfig) return;
+      if (!chartConfig) {
+        setChartSelected("");
+        setChartComponent(null);
+        return;
+      }
       const Chart = chartConfig.component;
       chartConfig.loader().then((data) => {
         setChartComponent(<Chart data={data} />);
@@ -409,6 +413,7 @@ const ImportPage = () => {
               direction="top"
               label="Choose the chart to display"
               items={chartsAvailable[source].map((chart) => chart.title)}
+              selectedItem={chartSelected}
               onChange={onChange}
             />
           </div>

--- a/src/pages/Import/index.tsx
+++ b/src/pages/Import/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { db, initDB } from "../../indexedDB";
 import {
   DenormalizedRow,
@@ -24,6 +24,42 @@ import KpiDashboard from "../Group13/KpiDashboard";
 import StackedLine from "../Group2/RecoverTrend";
 import AreaChartPage from "../fantasy/AreaChartPage";
 import VaccineDoseType from "../Group5/VaccineDoseType";
+
+const chartsAvailable: {
+  [key: string]: Array<{
+    title: string;
+    loader: () => Promise<unknown>;
+    component: any;
+  }>;
+} = {
+  "epidemic/cases_malaysia.csv": [
+    { title: "Box Plot", loader: boxPlotLoader, component: BoxPlot },
+    { title: "Histogram", loader: histogramLoader, component: Histogram },
+    {
+      title: "Line Chart",
+      loader: lineChartLoader,
+      component: LineChartPage,
+    },
+    { title: "KPI Dashboard", loader: casesLoader, component: KpiDashboard },
+    {
+      title: "Stacked Line Chart",
+      loader: stackedLineLoader,
+      component: StackedLine,
+    },
+  ],
+  "vaccination/vax_malaysia.csv": [
+    {
+      title: "Area Chart",
+      loader: areaChartLoader,
+      component: AreaChartPage,
+    },
+    {
+      title: "Stacked Area Chart",
+      loader: stackedAreaLoader,
+      component: VaccineDoseType,
+    },
+  ],
+};
 
 const ImportPage = () => {
   const [open, setOpen] = useState<
@@ -53,6 +89,7 @@ const ImportPage = () => {
     async () => {
       if (!db.isOpen()) await db.open();
       const record = await db.source.get(1);
+      if (!record) return "";
       return record.url.replace(
         "https://raw.githubusercontent.com/MoH-Malaysia/covid19-public/main/",
         ""
@@ -93,42 +130,7 @@ const ImportPage = () => {
     ],
     []
   );
-  const chartsAvailable: {
-    [key: string]: Array<{
-      title: string;
-      loader: () => Promise<any>;
-      component: any;
-    }>;
-  } = {
-    "epidemic/cases_malaysia.csv": [
-      { title: "Box Plot", loader: boxPlotLoader, component: BoxPlot },
-      { title: "Histogram", loader: histogramLoader, component: Histogram },
-      {
-        title: "Line Chart",
-        loader: lineChartLoader,
-        component: LineChartPage,
-      },
-      { title: "KPI Dashboard", loader: casesLoader, component: KpiDashboard },
-      {
-        title: "Stacked Line Chart",
-        loader: stackedLineLoader,
-        component: StackedLine,
-      },
-    ],
-    "vaccination/vax_malaysia.csv": [
-      {
-        title: "Area Chart",
-        loader: areaChartLoader,
-        component: AreaChartPage,
-      },
-      {
-        title: "Stacked Area Chart",
-        loader: stackedAreaLoader,
-        component: VaccineDoseType,
-      },
-    ],
-  };
-  const [chartSelected, setChartSelected] = useState<any>("");
+  const [chartSelected, setChartSelected] = useState<string>("");
   const [chartComponent, setChartComponent] = useState<any>(null);
 
   useEffect(() => {
@@ -147,10 +149,10 @@ const ImportPage = () => {
       });
     };
     renderChart();
-  }, [chartSelected, data]);
+  }, [chartSelected, data, source]);
 
   const onChange = (e: OnChangeData) => {
-    setChartSelected(e.selectedItem);
+    if (e.selectedItem) setChartSelected(e.selectedItem);
   };
 
   const searchText = (record: object) => {
@@ -304,9 +306,7 @@ const ImportPage = () => {
       });
   };
 
-  const closeNotification = (
-    _e: React.MouseEvent<HTMLButtonElement, MouseEvent>
-  ) => {
+  const closeNotification = () => {
     setShowNotification("");
     return true;
   };

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -8,8 +8,8 @@ const root =
 export const fetcher = async <T extends { [key: string]: string }>(
   url: string
 ): Promise<T[]> => {
-  if ((await db.source.get(1)).url === root + url)
-    return await db.store.toArray();
+  const record = await db.source.get(1);
+  if ((record && record.url) === root + url) return await db.store.toArray();
   const { data: csvData } = await axios.get(root + url);
   const { data } = Papa.parse<T>(csvData, { header: true });
   return data;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,10 +1,15 @@
 import axios from "axios";
 import Papa from "papaparse";
+import { db } from "../indexedDB";
 
 const root =
   "https://raw.githubusercontent.com/MoH-Malaysia/covid19-public/main/";
 
-export const fetcher = async <T extends {[key: string]: string}>(url: string): Promise<T[]> => {
+export const fetcher = async <T extends { [key: string]: string }>(
+  url: string
+): Promise<T[]> => {
+  if ((await db.source.get(1)).url === root + url)
+    return await db.store.toArray();
   const { data: csvData } = await axios.get(root + url);
   const { data } = Papa.parse<T>(csvData, { header: true });
   return data;


### PR DESCRIPTION
#### Changelog

**New**

- The import page will show a dropdown menu when user imported specific datasets using URL. The dropdown options are those visualisation graphs that uses the dataset imported. This function currently only supports two datasets:
- https://raw.githubusercontent.com/MoH-Malaysia/covid19-public/main/epidemic/cases_malaysia.csv. Dropdown options: Box Plot, Histogram, Line Chart, KPI Dashboard, Stacked Line Chart
- https://raw.githubusercontent.com/MoH-Malaysia/covid19-public/main/vaccination/vax_malaysia.csv. Dropdown options: Area Chart, Stacked Area Chart

**Changed**

- The charts in the import page will use the data stored in the indexedDB. Thus, by editing the data in the table, the values showing in the graph will change accordingly.

#### Screenshots

![image](https://github.com/omar-al-hendi/MyCovidView/assets/74411878/d3b56431-739a-4e83-8380-7d07cde8a509)

